### PR TITLE
Fix README.md so that relative links from manual become absolute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ library. It can convert *from*
   - `gfm` ([GitHub-Flavored
     Markdown](https://help.github.com/articles/github-flavored-markdown/)),
     or the deprecated and less accurate `markdown_github`; use
-    [`markdown_github`](#markdown-variants) only if you need extensions
-    not supported in [`gfm`](#markdown-variants).
+    [`markdown_github`](https://pandoc.org/MANUAL.html#markdown-variants)
+    only if you need extensions not supported in
+    [`gfm`](https://pandoc.org/MANUAL.html#markdown-variants).
   - `haddock` ([Haddock
     markup](https://www.haskell.org/haddock/doc/html/ch03s08.html))
   - `html` ([HTML](http://www.w3.org/html/))
@@ -49,7 +50,8 @@ library. It can convert *from*
   - `jats` ([JATS](https://jats.nlm.nih.gov) XML)
   - `json` (JSON version of native AST)
   - `latex` ([LaTeX](http://latex-project.org))
-  - `markdown` ([Pandoc’s Markdown](#pandocs-markdown))
+  - `markdown` ([Pandoc’s
+    Markdown](https://pandoc.org/MANUAL.html#pandocs-markdown))
   - `markdown_mmd`
     ([MultiMarkdown](http://fletcherpenney.net/multimarkdown/))
   - `markdown_phpextra` ([PHP Markdown
@@ -98,8 +100,9 @@ It can convert *to*
   - `gfm` ([GitHub-Flavored
     Markdown](https://help.github.com/articles/github-flavored-markdown/)),
     or the deprecated and less accurate `markdown_github`; use
-    [`markdown_github`](#markdown-variants) only if you need extensions
-    not supported in [`gfm`](#markdown-variants).
+    [`markdown_github`](https://pandoc.org/MANUAL.html#markdown-variants)
+    only if you need extensions not supported in
+    [`gfm`](https://pandoc.org/MANUAL.html#markdown-variants).
   - `haddock` ([Haddock
     markup](https://www.haskell.org/haddock/doc/html/ch03s08.html))
   - `html` or `html5` ([HTML](http://www.w3.org/html/),
@@ -118,7 +121,8 @@ It can convert *to*
   - `latex` ([LaTeX](http://latex-project.org))
   - `man` ([roff
     man](http://man7.org/linux/man-pages/man7/groff_man.7.html))
-  - `markdown` ([Pandoc’s Markdown](#pandocs-markdown))
+  - `markdown` ([Pandoc’s
+    Markdown](https://pandoc.org/MANUAL.html#pandocs-markdown))
   - `markdown_mmd`
     ([MultiMarkdown](http://fletcherpenney.net/multimarkdown/))
   - `markdown_phpextra` ([PHP Markdown
@@ -163,7 +167,7 @@ It can convert *to*
   - `zimwiki` ([ZimWiki
     markup](http://zim-wiki.org/manual/Help/Wiki_Syntax.html))
   - the path of a custom lua writer, see [Custom
-    writers](#custom-writers) below
+    writers](https://pandoc.org/MANUAL.html#custom-writers) below
 
 </div>
 

--- a/tools/update-readme.lua
+++ b/tools/update-readme.lua
@@ -8,15 +8,21 @@ f:close()
 result = {}
 
 function Div(elem)
-    local ident = elem.identifier or ""
-    local get = function(el)
-                    if el.identifier == ident then
-                        result = el
-                    end
-                end
-    if ident == 'input-formats' or ident == 'output-formats' then
-      pandoc.walk_block(pandoc.Div(mdoc.blocks), { Div = get })
-      return result
+  local ident = elem.identifier or ""
+  local fixrel = function(el)
+    if el.target:match("^#") then
+      el.target = "https://pandoc.org/MANUAL.html" .. el.target
     end
+    return el
+  end
+  local get = function(el)
+    if el.identifier == ident then
+      result = pandoc.walk_block(el, { Link = fixrel  })
+    end
+  end
+  if ident == 'input-formats' or ident == 'output-formats' then
+    pandoc.walk_block(pandoc.Div(mdoc.blocks), { Div = get })
+    return result
+  end
 end
 


### PR DESCRIPTION
Previously they'd be broken links when viewed on GitHub or Hackage.
So we add the base URL for the pandoc manual.