### PR TITLE
Org reader: add table labels to caption if both are present

### DIFF
--- a/test/command/3706.md
+++ b/test/command/3706.md
@@ -15,7 +15,7 @@ pandoc -f org -t native
 |  2 | La   |
 |  3 | La   |
 ^D
-[Table [Str "Lalelu."] [AlignDefault,AlignDefault] [0.0,0.0]
+[Table [Span ("tab",[],[]) [],Str "Lalelu."] [AlignDefault,AlignDefault] [0.0,0.0]
  [[Plain [Str "Id"]]
  ,[Plain [Str "Desc"]]]
  [[[Plain [Str "1"]]


### PR DESCRIPTION
The table `#+NAME:` or `#+LABEL:` is added to the table's caption in the
form of an empty span with the label set as the span's ID.

Closes: #5984