### PR TITLE
LaTeX writer: properly handle unnumbered headings level 4+.

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -1010,7 +1010,7 @@ sectionHeader classes ident level lst = do
                   -- see http://tex.stackexchange.com/questions/169830/
                   else empty
   lab <- labelFor ident
-  let star = if unnumbered && level' < 4 then text "*" else empty
+  let star = if unnumbered then text "*" else empty
   let stuffing = star <> optional <> contents
   stuffing' <- hypertarget True ident $
                   text ('\\':sectionType) <> stuffing <> lab

--- a/test/Tests/Writers/LaTeX.hs
+++ b/test/Tests/Writers/LaTeX.hs
@@ -170,7 +170,7 @@ tests = [ testGroup "code blocks"
                       , "\\addcontentsline{toc}{subsection}{header4}\n"
                       , "\\subsubsection*{header5}"
                       , "\\addcontentsline{toc}{subsubsection}{header5}\n"
-                      , "\\paragraph{header6}"
+                      , "\\paragraph*{header6}"
                       , "\\addcontentsline{toc}{paragraph}{header6}"
                       ]
             ]


### PR DESCRIPTION
Closes #6018.

Previously the `\paragraph` command was used instead of
`\paragraph*` for unnumbered level 4 headings.