### PR TITLE
Reveal.js writer: restore old behavior for 2D nesting.

### DIFF
--- a/test/command/6030.md
+++ b/test/command/6030.md
@@ -15,12 +15,20 @@ Three
 #### Four
 
 Four
+
+# New sec
+
+New sec
+
+## New sub
+
+New sub
 ^D
+<section>
 <section id="one" class="title-slide slide level1">
 <h1>One</h1>
 <p>One</p>
 </section>
-<section>
 <section id="two" class="title-slide slide level2">
 <h2>Two</h2>
 <p>Two</p>
@@ -30,6 +38,16 @@ Four
 <p>Three</p>
 <h4 id="four">Four</h4>
 <p>Four</p>
+</section>
+</section>
+<section>
+<section id="new-sec" class="title-slide slide level1">
+<h1>New sec</h1>
+<p>New sec</p>
+</section>
+<section id="new-sub" class="title-slide slide level2">
+<h2>New sub</h2>
+<p>New sub</p>
 </section>
 </section>
 ```


### PR DESCRIPTION
The fix to #6030 actually changed behavior, so that the
2D nesting occurred at slide level N-1 and N, instead of
at the top-level section.  This commit restores the 2.7.3 behavior.
If there are more than 2 levels, the top level is horizontal
and the rest are collapsed to vertical.

Closes #6032.