### PR TITLE
docs: capitalize Lua where it refers to the programming language name

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -325,7 +325,7 @@ header when requesting a document from a URL:
     - `tei` ([TEI Simple])
     - `xwiki` ([XWiki markup])
     - `zimwiki` ([ZimWiki markup])
-    - the path of a custom lua writer, see [Custom writers] below
+    - the path of a custom Lua writer, see [Custom writers] below
     :::
 
     Note that `odt`, `docx`, `epub`, and `pdf` output will not be directed
@@ -574,22 +574,22 @@ header when requesting a document from a URL:
 
      3. `$PATH` (executable only)
 
-    Filters and lua-filters are applied in the order specified
+    Filters and Lua-filters are applied in the order specified
     on the command line.
 
 `-L` *SCRIPT*, `--lua-filter=`*SCRIPT*
 
 :   Transform the document in a similar fashion as JSON filters (see
-    `--filter`), but use pandoc's build-in lua filtering system.  The given
-    lua script is expected to return a list of lua filters which will be
-    applied in order.  Each lua filter must contain element-transforming
+    `--filter`), but use pandoc's build-in Lua filtering system.  The given
+    Lua script is expected to return a list of Lua filters which will be
+    applied in order.  Each Lua filter must contain element-transforming
     functions indexed by the name of the AST element on which the filter
     function should be applied.
 
-    The `pandoc` lua module provides helper functions for element
-    creation.  It is always loaded into the script's lua environment.
+    The `pandoc` Lua module provides helper functions for element
+    creation.  It is always loaded into the script's Lua environment.
 
-    The following is an example lua script for macro-expansion:
+    The following is an example Lua script for macro-expansion:
 
         function expand_hello_world(inline)
           if inline.c == '{{helloworld}}' then
@@ -601,7 +601,7 @@ header when requesting a document from a URL:
 
         return {{Str = expand_hello_world}}
 
-    In order of preference, pandoc will look for lua filters in
+    In order of preference, pandoc will look for Lua filters in
 
      1. a specified full or relative path (executable or
      non-executable)
@@ -1477,7 +1477,7 @@ include-after-body: []
 include-in-header: []
 resource-path: ["."]
 
-# filters will be assumed to be lua filters if they have
+# filters will be assumed to be Lua filters if they have
 # the .lua extension, and json filters otherwise.  But
 # the filter type can also be specified explicitly, as shown:
 filters:
@@ -5829,15 +5829,15 @@ same styles in your input and output files.
 
 # Custom writers
 
-Pandoc can be extended with custom writers written in [lua].  (Pandoc
-includes a lua interpreter, so lua need not be installed separately.)
+Pandoc can be extended with custom writers written in [Lua].  (Pandoc
+includes a Lua interpreter, so Lua need not be installed separately.)
 
-To use a custom writer, simply specify the path to the lua script
+To use a custom writer, simply specify the path to the Lua script
 in place of the output format. For example:
 
     pandoc -t data/sample.lua
 
-Creating a custom writer requires writing a lua function for each
+Creating a custom writer requires writing a Lua function for each
 possible element in a pandoc document.  To get a documented example
 which you can modify according to your needs, do
 
@@ -5850,7 +5850,7 @@ default template with the name
 `default.NAME_OF_CUSTOM_WRITER.lua` to the `templates`
 subdirectory of your user data directory (see [Templates]).
 
-[lua]: http://www.lua.org
+[Lua]: http://www.lua.org
 
 # A note on security
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ It can convert *to*
     markup](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/XWikiSyntax/))
   - `zimwiki` ([ZimWiki
     markup](http://zim-wiki.org/manual/Help/Wiki_Syntax.html))
-  - the path of a custom lua writer, see [Custom
+  - the path of a custom Lua writer, see [Custom
     writers](https://pandoc.org/MANUAL.html#custom-writers) below
 
 </div>
@@ -188,7 +188,7 @@ convert this native representation into a target format. Thus, adding an
 input or output format requires only adding a reader or writer. Users
 can also run custom pandoc filters to modify the intermediate AST (see
 the documentation for [filters](https://pandoc.org/filters.html) and
-[lua filters](https://pandoc.org/lua-filters.html)).
+[Lua filters](https://pandoc.org/lua-filters.html)).
 
 Because pandoc’s intermediate representation of a document is less
 expressive than many of the formats it converts between, one should not

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -29,13 +29,13 @@ used by anyone who has a certain version of the pandoc
 executable.
 
 Starting with version 2.0, pandoc makes it possible to write
-filters in lua without any external dependencies at all. A lua
-interpreter (version 5.3) and a lua library for creating pandoc
+filters in Lua without any external dependencies at all. A Lua
+interpreter (version 5.3) and a Lua library for creating pandoc
 filters is built into the pandoc executable. Pandoc data types
-are marshalled to lua directly, avoiding the overhead of writing
+are marshalled to Lua directly, avoiding the overhead of writing
 JSON to stdout and reading it from stdin.
 
-Here is an example of a lua filter that converts strong emphasis
+Here is an example of a Lua filter that converts strong emphasis
 to small caps:
 
 ``` lua
@@ -74,7 +74,7 @@ Python (`smallcaps.py`):
   `pandoc --filter ./smallcaps.py`        1.40s
   `pandoc --lua-filter ./smallcaps.lua`   1.03s
 
-As you can see, the lua filter avoids the substantial overhead
+As you can see, the Lua filter avoids the substantial overhead
 associated with marshalling to and from JSON over a pipe.
 
 # Lua filter structure
@@ -91,10 +91,10 @@ then it would be applied like this:
 
 The `--lua-filter` option may be supplied multiple times. Pandoc
 applies all filters (including JSON filters specified via
-`--filter` and lua filters specified via `--lua-filter`) in the
+`--filter` and Lua filters specified via `--lua-filter`) in the
 order they appear on the command line.
 
-Pandoc expects each lua file to return a list of filters. The
+Pandoc expects each Lua file to return a list of filters. The
 filters in that list are called sequentially, each on the result
 of the previous filter. If there is no value returned by the
 filter script, then pandoc will try to generate a single filter
@@ -104,7 +104,7 @@ those of pandoc elements (e.g., `Str`, `Para`, `Meta`, or
 
 For each filter, the document is traversed and each element
 subjected to the filter. Elements for which the filter contains
-an entry (i.e. a function of the same name) are passed to lua
+an entry (i.e. a function of the same name) are passed to Lua
 element filtering function. In other words, filter entries will
 be called for each corresponding element in the document,
 getting the respective element as input.
@@ -208,7 +208,7 @@ variables.
 
 # Pandoc Module
 
-The `pandoc` lua module is loaded into the filter's lua
+The `pandoc` Lua module is loaded into the filter's Lua
 environment and provides a set of functions and constants to
 make creation and manipulation of elements easier. The global
 variable `pandoc` is bound to the module and should generally
@@ -222,15 +222,15 @@ functionalities.
 
 Element creator functions like `Str`, `Para`, and `Pandoc` are
 designed to allow easy creation of new elements that are simple
-to use and can be read back from the lua environment.
-Internally, pandoc uses these functions to create the lua
+to use and can be read back from the Lua environment.
+Internally, pandoc uses these functions to create the Lua
 objects which are passed to element filter functions. This means
 that elements created via this module will behave exactly as
 those elements accessible through the filter function parameter.
 
 ## Exposed pandoc functionality
 
-Some pandoc functions have been made available in lua:
+Some pandoc functions have been made available in Lua:
 
 -   [`walk_block`](#pandoc.walk_block) and
     [`walk_inline`](#pandoc.walk_inline) allow filters to be applied
@@ -269,7 +269,7 @@ colon syntax (`mystring:uc_upper()`).
 # Examples
 
 The following filters are presented as examples. A repository of
-useful lua filters (which may also serve as good examples) is
+useful Lua filters (which may also serve as good examples) is
 available at <https://github.com/pandoc/lua-filters>.
 
 ## Macro substitution
@@ -2478,7 +2478,7 @@ Parameters:
 :   the block element
 
 `filter`:
-:   a lua filter (table of functions) to be applied within the
+:   a Lua filter (table of functions) to be applied within the
     block element
 
 Returns: the transformed block element
@@ -2495,7 +2495,7 @@ Parameters:
 :   the inline element
 
 `filter`:
-:   a lua filter (table of functions) to be applied within the
+:   a Lua filter (table of functions) to be applied within the
     inline element
 
 Returns: the transformed inline element


### PR DESCRIPTION
This follows the advise on the Lua
website (https://www.lua.org/about.html#name):

> […] "Lua" is a name, the name of the Earth's moon and the name of the
> language. Like most names, it should be written in lower case with an
> initial capital, that is, "Lua".