### PR TITLE
HTML writer: fix duplicate attributes on headings.

### DIFF
--- a/test/command/6062.md
+++ b/test/command/6062.md
@@ -1,0 +1,6 @@
+```
+% pandoc -f native -t html
+[Header 1 ("section",["foo","unnumbered"],[("key","val")]) [Str "1"]]
+^D
+<h1 class="foo unnumbered" data-key="val" id="section">1</h1>
+```


### PR DESCRIPTION
Another regression from 2.7.x. Closes #6062.