### PR TITLE
Update versions for doclayout, doctemplates.

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -424,7 +424,7 @@ library
                  case-insensitive >= 1.2 && < 1.3,
                  unicode-transforms >= 0.3 && < 0.4,
                  HsYAML >= 0.2 && < 0.3,
-                 doclayout >= 0.2.0.1 && < 0.3,
+                 doclayout >= 0.3 && < 0.4,
                  ipynb >= 0.1 && < 0.2,
                  attoparsec >= 0.12 && < 0.14,
                  text-conversions >= 0.3 && < 0.4,

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,12 +18,12 @@ extra-deps:
 - skylighting-0.8.3
 - skylighting-core-0.8.3
 - regex-pcre-builtin-0.95.0.8.8.35
-- doclayout-0.2.0.1
+- doclayout-0.3
 - emojis-0.1
 - jira-wiki-markup-1.0.0
 - HsYAML-0.2.0.0
 - HsYAML-aeson-0.2.0.0
-- doctemplates-0.8
+- doctemplates-0.8.1
 - pandoc-citeproc-0.16.4.1
 ghc-options:
    "$locals": -fhide-source-paths -Wno-missing-home-modules


### PR DESCRIPTION
Closes #6031.  The new version of doclayout fixes a
memory leak that affected `--include-in-header` with
large files (and possibly other cases involving extremely
long lines).