### PR TITLE
Lua filters: allow filtering of element lists (#6040)

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -605,9 +605,10 @@ library
                    Text.Pandoc.Lua.Marshaling.AST,
                    Text.Pandoc.Lua.Marshaling.AnyValue,
                    Text.Pandoc.Lua.Marshaling.CommonState,
+                   Text.Pandoc.Lua.Marshaling.Context,
+                   Text.Pandoc.Lua.Marshaling.List,
                    Text.Pandoc.Lua.Marshaling.MediaBag,
                    Text.Pandoc.Lua.Marshaling.ReaderOptions,
-                   Text.Pandoc.Lua.Marshaling.Context,
                    Text.Pandoc.Lua.Marshaling.Version,
                    Text.Pandoc.Lua.Module.MediaBag,
                    Text.Pandoc.Lua.Module.Pandoc,
@@ -838,4 +839,3 @@ benchmark benchmark-pandoc
                      -Widentities
                      -Werror=missing-home-modules
                      -fhide-source-paths
-

--- a/src/Text/Pandoc/Lua/Init.hs
+++ b/src/Text/Pandoc/Lua/Init.hs
@@ -119,6 +119,7 @@ putConstructorsInRegistry = do
   constrsToReg $ Pandoc.Citation mempty mempty mempty Pandoc.AuthorInText 0 0
   putInReg "Attr"  -- used for Attr type alias
   putInReg "ListAttributes"  -- used for ListAttributes type alias
+  putInReg "List"  -- pandoc.List
  where
   constrsToReg :: Data a => a -> Lua ()
   constrsToReg = mapM_ (putInReg . showConstr) . dataTypeConstrs . dataTypeOf

--- a/src/Text/Pandoc/Lua/Marshaling/List.hs
+++ b/src/Text/Pandoc/Lua/Marshaling/List.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DeriveDataTypeable   #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude    #-}
+{-# LANGUAGE UndecidableInstances #-}
+{- |
+Module      : Text.Pandoc.Lua.Marshaling.List
+Copyright   : © 2012-2020 John MacFarlane
+              © 2017-2020 Albert Krewinkel
+License     : GNU GPL, version 2 or above
+Maintainer  : Albert Krewinkel <tarleb+pandoc@moltkeplatz.de>
+Stability   : alpha
+
+Marshaling/unmarshaling instances for @pandoc.List@s.
+-}
+module Text.Pandoc.Lua.Marshaling.List
+  ( List (..)
+  ) where
+
+import Prelude
+import Data.Data (Data)
+import Foreign.Lua (Peekable, Pushable)
+import Text.Pandoc.Walk (Walkable (..))
+import Text.Pandoc.Lua.Util (defineHowTo, pushViaConstructor)
+
+import qualified Foreign.Lua as Lua
+
+-- | List wrapper which is marshalled as @pandoc.List@.
+newtype List a = List { fromList :: [a] }
+  deriving (Data, Eq, Show)
+
+instance Pushable a => Pushable (List a) where
+  push (List xs) =
+    pushViaConstructor "List" xs
+
+instance Peekable a => Peekable (List a) where
+  peek idx = defineHowTo "get List" $ do
+    xs <- Lua.peek idx
+    return $ List xs
+
+-- List is just a wrapper, so we can reuse the walk instance for
+-- unwrapped Hasekll lists.
+instance Walkable [a] b => Walkable (List a) b where
+  walkM f = walkM (fmap fromList . f . List)
+  query f = query (f . List)

--- a/test/Tests/Lua.hs
+++ b/test/Tests/Lua.hs
@@ -23,7 +23,8 @@ import Text.Pandoc.Arbitrary ()
 import Text.Pandoc.Builder (bulletList, definitionList, displayMath, divWith,
                             doc, doubleQuoted, emph, header, lineBlock,
                             linebreak, math, orderedList, para, plain, rawBlock,
-                            singleQuoted, space, str, strong)
+                            singleQuoted, space, str, strong,
+                            HasMeta (setMeta))
 import Text.Pandoc.Class (runIOorExplode, setUserDataDir)
 import Text.Pandoc.Definition (Block (BlockQuote, Div, Para), Inline (Emph, Str),
                                Attr, Meta, Pandoc, pandocTypesVersion)
@@ -128,6 +129,28 @@ tests = map (localOption (QuickCheckTests 20))
       "attr-test.lua"
       (doc $ divWith ("", [], kv_before) (para "nil"))
       (doc $ divWith ("", [], kv_after) (para "nil"))
+
+  , testCase "Filter list of inlines" $
+      assertFilterConversion "List of inlines"
+      "inlines-filter.lua"
+      (doc $ para ("Hello," <> linebreak <> "World! Wassup?"))
+      (doc $ para "Hello, World! Wassup?")
+
+  , testCase "Filter list of blocks" $
+      assertFilterConversion "List of blocks"
+      "blocks-filter.lua"
+      (doc $ para "one." <> para "two." <> para "three.")
+      (doc $ plain "3")
+
+  , testCase "Filter Meta" $
+    let setMetaBefore = setMeta "old" ("old" :: T.Text)
+                      . setMeta "bool" False
+        setMetaAfter  = setMeta "new" ("new" :: T.Text)
+                      . setMeta "bool" True
+    in assertFilterConversion "Meta filtering"
+      "meta.lua"
+      (setMetaBefore . doc $ mempty)
+      (setMetaAfter . doc $ mempty)
 
   , testCase "Script filename is set" $
     assertFilterConversion "unexpected script name"

--- a/test/lua/blocks-filter.lua
+++ b/test/lua/blocks-filter.lua
@@ -1,0 +1,8 @@
+function Blocks (blks)
+  -- verify that this looks like a `pandoc.List`
+  if not blks.find or not blks.map or not blks.filter then
+    error("table doesn't seem to be an instance of pandoc.List")
+  end
+  -- return plain block containing the number of elements in the list
+  return {pandoc.Plain {pandoc.Str(tostring(#blks))}}
+end

--- a/test/lua/inlines-filter.lua
+++ b/test/lua/inlines-filter.lua
@@ -1,0 +1,19 @@
+function isWorldAfterSpace (fst, snd)
+  return fst and fst.t == 'LineBreak'
+   and snd and snd.t == 'Str' and snd.text == 'World!'
+end
+
+function Inlines (inlns)
+  -- verify that this looks like a `pandoc.List`
+  if not inlns.find or not inlns.map or not inlns.filter then
+    error("table doesn't seem to be an instance of pandoc.List")
+  end
+
+  -- Remove spaces before string "World"
+  for i = #inlns-1,1,-1 do
+    if isWorldAfterSpace(inlns[i], inlns[i+1]) then
+      inlns[i] = pandoc.Space()
+    end
+  end
+  return inlns
+end

--- a/test/lua/meta.lua
+++ b/test/lua/meta.lua
@@ -1,0 +1,6 @@
+function Meta (meta)
+  meta.old = nil
+  meta.new = "new"
+  meta.bool = (meta.bool == false)
+  return meta
+end


### PR DESCRIPTION
Lists of Inline and Block elements can now be filtered via `Inlines` and
`Blocks` functions, respectively. This is helpful if a filter conversion
depends on the order of elements rather than a single element.

For example, the following filter can be used to remove all spaces
before a citation:

    function isSpaceBeforeCite (spc, cite)
      return spc and spc.t == 'Space'
       and cite and cite.t == 'Cite'
    end

    function Inlines (inlines)
      for i = #inlines-1,1,-1 do
        if isSpaceBeforeCite(inlines[i], inlines[i+1]) then
          inlines:remove(i)
        end
      end
      return inlines
    end

Closes: #6038