### PR TITLE
Added a try that was needed for the commit fc78be1.

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1942,7 +1942,7 @@ environment = try $ do
     if M.member name (inlineEnvironments
                        :: M.Map Text (LP PandocPure Inlines))
        then mzero
-       else rawEnv name <|> rawVerbEnv name
+       else try (rawEnv name) <|> rawVerbEnv name
 
 env :: PandocMonad m => Text -> LP m a -> LP m a
 env name p = p <* end_ name


### PR DESCRIPTION
The intent of that commit was to parse unknown LaTeX
enivronments as verbatim if they can't be parsed normally,
avoiding crashes on environments that allow unescaped
underscores and the like.  But the fix didn't completely
work: it worked for raw TeX in markdown but not when
reading LaTeX. This change fixes that.

See #6034. Closes #6093.