### PR TITLE
LaTeX template: add space option to xeCJK with PassOptionsToPackage.

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -9,6 +9,9 @@ $if(latex-dir-rtl)$
 \PassOptionsToPackage{RTLdocument}{bidi}
 $endif$
 $endif$
+$if(CJKmainfont)$
+\PassOptionsToPackage{space}{xeCJK}
+$endif$
 %
 \documentclass[
 $if(fontsize)$
@@ -137,7 +140,7 @@ $endif$
 $endif$
 $if(CJKmainfont)$
   \ifxetex
-    \usepackage[space]{xeCJK}
+    \usepackage{xeCJK}
     \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
   \fi
 $endif$


### PR DESCRIPTION
Otherwise we can get a clash with documentclasses that
already load the package.  Closes #6002.