### PR TITLE
Fix table alignment when heading begins with t.

### DIFF
--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1183,7 +1183,7 @@ alignType strLst len =
   let nonempties = filter (not . T.null) $ map trimr strLst
       (leftSpace, rightSpace) =
            case sortOn T.length nonempties of
-                 (x:_) -> (T.head x `elem` [' ', 't'], T.length x < len)
+                 (x:_) -> (T.head x `elem` [' ', '\t'], T.length x < len)
                  []    -> (False, False)
   in  case (leftSpace, rightSpace) of
         (True,  False) -> AlignRight


### PR DESCRIPTION
Due to a typo (`t` instead of `\t`) we were center
aligning column headings that begin with a lowercase t!
Closes #6153.