### PR TITLE
EPUB writer: fix regression on detection of front/back/bodymatter.

### DIFF
--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -595,7 +595,8 @@ pandocToEPUB version opts doc = do
                             <> cssvars True <> vars } pdoc
          where (pdoc, bodyType) =
                  case bs of
-                     (Header _ (_,_,kvs) xs : _) ->
+                     (Div (_,"section":_,kvs)
+                       (Header _ _ xs : _) : _) ->
                        -- remove notes or we get doubled footnotes
                        (Pandoc (setMeta "title"
                            (walk removeNote $ fromList xs) nullMeta) bs,


### PR DESCRIPTION
This bug caused sections with epub:type "dedication" to be
misplaced in bodymatter instead of frontmatter as specified
in the manual.  The same problem would affect other epub:types.

The pattern matching needed to be changed with the use of
`makeSection`.  Closes #6170.