### PR TITLE
Ms writer: fix definition lists so indent even when...

### DIFF
--- a/src/Text/Pandoc/Writers/Ms.hs
+++ b/src/Text/Pandoc/Writers/Ms.hs
@@ -321,8 +321,9 @@ definitionListItemToMs opts (label, defs) = do
                         rest' <- liftM vcat $
                                   mapM (\item -> blockToMs opts item) rest
                         first' <- blockToMs opts first
-                        return $ first' $$ literal ".RS" $$ rest' $$ literal ".RE"
-  return $ nowrap (literal ".IP " <> doubleQuotes labelText) $$ contents
+                        return $ first' $$ literal ".RS 3" $$ rest' $$ literal ".RE"
+  return $ nowrap (literal ".IP " <> doubleQuotes labelText <> " 3") $$
+           contents
 
 -- | Convert list of Pandoc block elements to ms.
 blockListToMs :: PandocMonad m
@@ -400,7 +401,7 @@ inlineToMs opts (Math DisplayMath str) = do
   case res of
        Left il -> do
          contents <- inlineToMs opts il
-         return $ cr <> literal ".RS" $$ contents $$ literal ".RE"
+         return $ cr <> literal ".RS 3" $$ contents $$ literal ".RE"
        Right r -> return $
             cr <> literal ".EQ" $$ literal r $$ literal ".EN" <> cr
 inlineToMs _ il@(RawInline f str)

--- a/test/writer.ms
+++ b/test/writer.ms
@@ -445,57 +445,57 @@ Definition Lists
 .pdfhref M "definition-lists"
 .LP
 Tight using spaces:
-.IP "\f[B]apple\f[R]"
+.IP "\f[B]apple\f[R]" 3
 red fruit
-.RS
+.RS 3
 .RE
-.IP "\f[B]orange\f[R]"
+.IP "\f[B]orange\f[R]" 3
 orange fruit
-.RS
+.RS 3
 .RE
-.IP "\f[B]banana\f[R]"
+.IP "\f[B]banana\f[R]" 3
 yellow fruit
-.RS
+.RS 3
 .RE
 .LP
 Tight using tabs:
-.IP "\f[B]apple\f[R]"
+.IP "\f[B]apple\f[R]" 3
 red fruit
-.RS
+.RS 3
 .RE
-.IP "\f[B]orange\f[R]"
+.IP "\f[B]orange\f[R]" 3
 orange fruit
-.RS
+.RS 3
 .RE
-.IP "\f[B]banana\f[R]"
+.IP "\f[B]banana\f[R]" 3
 yellow fruit
-.RS
+.RS 3
 .RE
 .LP
 Loose:
-.IP "\f[B]apple\f[R]"
+.IP "\f[B]apple\f[R]" 3
 red fruit
-.RS
+.RS 3
 .RE
-.IP "\f[B]orange\f[R]"
+.IP "\f[B]orange\f[R]" 3
 orange fruit
-.RS
+.RS 3
 .RE
-.IP "\f[B]banana\f[R]"
+.IP "\f[B]banana\f[R]" 3
 yellow fruit
-.RS
+.RS 3
 .RE
 .LP
 Multiple blocks with italics:
-.IP "\f[B]\f[BI]apple\f[B]\f[R]"
+.IP "\f[B]\f[BI]apple\f[B]\f[R]" 3
 red fruit
-.RS
+.RS 3
 .PP
 contains seeds, crisp, pleasant to taste
 .RE
-.IP "\f[B]\f[BI]orange\f[B]\f[R]"
+.IP "\f[B]\f[BI]orange\f[B]\f[R]" 3
 orange fruit
-.RS
+.RS 3
 .IP
 .nf
 \f[C]
@@ -509,48 +509,48 @@ orange block quote
 .RE
 .LP
 Multiple definitions, tight:
-.IP "\f[B]apple\f[R]"
+.IP "\f[B]apple\f[R]" 3
 red fruit
-.RS
+.RS 3
 .RE
 computer
-.RS
+.RS 3
 .RE
-.IP "\f[B]orange\f[R]"
+.IP "\f[B]orange\f[R]" 3
 orange fruit
-.RS
+.RS 3
 .RE
 bank
-.RS
+.RS 3
 .RE
 .LP
 Multiple definitions, loose:
-.IP "\f[B]apple\f[R]"
+.IP "\f[B]apple\f[R]" 3
 red fruit
-.RS
+.RS 3
 .RE
 computer
-.RS
+.RS 3
 .RE
-.IP "\f[B]orange\f[R]"
+.IP "\f[B]orange\f[R]" 3
 orange fruit
-.RS
+.RS 3
 .RE
 bank
-.RS
+.RS 3
 .RE
 .LP
 Blank line after term, indented marker, alternate markers:
-.IP "\f[B]apple\f[R]"
+.IP "\f[B]apple\f[R]" 3
 red fruit
-.RS
+.RS 3
 .RE
 computer
-.RS
+.RS 3
 .RE
-.IP "\f[B]orange\f[R]"
+.IP "\f[B]orange\f[R]" 3
 orange fruit
-.RS
+.RS 3
 .IP " 1." 4
 sublist
 .IP " 2." 4


### PR DESCRIPTION
paragraph indent is set to 0 (as is the default).

Also ensure indent for display math that falls back
to TeX.