### PR TITLE
Jira reader: fix parsing of strikeout, emphasis

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -412,7 +412,7 @@ library
                  blaze-html >= 0.9 && < 0.10,
                  blaze-markup >= 0.8 && < 0.9,
                  vector >= 0.10 && < 0.13,
-                 jira-wiki-markup >= 1.1 && < 1.2,
+                 jira-wiki-markup >= 1.1.2 && < 1.2,
                  hslua >= 1.0.1 && < 1.1,
                  hslua-module-system >= 0.2 && < 0.3,
                  hslua-module-text >= 0.2 && < 0.3,

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,7 @@ extra-deps:
 - regex-pcre-builtin-0.95.0.8.8.35
 - doclayout-0.3
 - emojis-0.1
-- jira-wiki-markup-1.1.0
+- jira-wiki-markup-1.1.2
 - HsYAML-0.2.0.0
 - HsYAML-aeson-0.2.0.0
 - doctemplates-0.8.1

--- a/test/Tests/Readers/Jira.hs
+++ b/test/Tests/Readers/Jira.hs
@@ -114,5 +114,9 @@ tests =
 
     , "HTML entity" =:
       "me &amp; you" =?> para "me & you"
+
+    , "non-strikeout dashes" =:
+      "20.09-15 2-678" =?>
+      para "20.09-15 2-678"
     ]
   ]


### PR DESCRIPTION
A bug was fixed which caused non-emphasized text containing digits and/or
non-special symbols (like dots) to sometimes be parsed incorrectly.

Fixes: #6196